### PR TITLE
:feat: user delete mutation

### DIFF
--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -26,4 +26,12 @@ module.exports = {
             throw new errorObject({ message: error.message })
         }
     },
+    deleteUser: async (id) => {
+        try {
+            const user = await userService.remove(id)
+            return user
+        } catch (error) {
+            throw new errorObject({ message: error.message })
+        }
+    }
 }

--- a/src/graphql/mutation/deleteUser.js
+++ b/src/graphql/mutation/deleteUser.js
@@ -1,0 +1,6 @@
+const userController = require('../../controllers/user.controller')
+
+module.exports = (parent, args, context) => {
+    const user = userController.deleteUser(args.id)
+    return user
+}

--- a/src/graphql/resolvers.js
+++ b/src/graphql/resolvers.js
@@ -8,5 +8,6 @@ module.exports = {
     },
     Mutation: {
         createNewUser: require('./mutation/createNewUser'),
+        deleteUser: require('./mutation/deleteUser'),
     },
 }

--- a/src/graphql/typeDefs/Mutation.gql
+++ b/src/graphql/typeDefs/Mutation.gql
@@ -7,4 +7,9 @@ type Mutation {
     Returns a User type (click User to see more).
     """
     createNewUser(username: String!, email: String!, password: String!): User!
+    """
+    Used for delete a user in the system, requires a valid user id.
+    Returns a User type (click User to see more).
+    """
+    deleteUser(id: ID!): User!
 }


### PR DESCRIPTION
# Description
Added delete user using his id mutation.

## Type
- [ ] Bug fix
- [X] New feature
- [ ] Refactor

## Evidence
Here is the new mutation documentation.
![Captura de pantalla 2023-01-28 145946](https://user-images.githubusercontent.com/101936353/215284055-01a7be4c-5190-4934-aeba-4ec057b4107c.png)

We're gonna list some users created before using `query {  users { id } }`.
![Captura de pantalla 2023-01-28 150623](https://user-images.githubusercontent.com/101936353/215284103-75797fce-81cc-4183-8275-311158772d3d.png)

For example: we'll delete **martinez** using his id.
![Captura de pantalla 2023-01-28 150855](https://user-images.githubusercontent.com/101936353/215284173-1a163e45-67c3-4d4b-925b-f47be742a82c.png)

Deleted.
![Captura de pantalla 2023-01-28 150928](https://user-images.githubusercontent.com/101936353/215284215-87276a9c-2018-4986-aef6-d70305016dde.png)

Check if it is working calling all users again with query type.
![Captura de pantalla 2023-01-28 150954](https://user-images.githubusercontent.com/101936353/215284252-f119b873-22d3-4c2f-b8bb-20827278ed68.png)
