### PR TITLE
fix: can delete a admin

### DIFF
--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -43,8 +43,12 @@ module.exports = {
     deleteUser: async (executer, id) => {
         try {
             verifyOwnership(executer, id)
-            const user = await userService.remove(id)
-            return user
+            const user = await userService.findById(id)
+            if (!user) throw new Error('User not found')
+            if (user.role === 'admin')
+                throw new Error('You cannot delete an admin user')
+            await userService.remove(id)
+            return 'User deleted successfully'
         } catch (error) {
             throw new errorObject({ message: error.message })
         }

--- a/src/graphql/mutation/deleteUser.js
+++ b/src/graphql/mutation/deleteUser.js
@@ -1,6 +1,5 @@
 const userController = require('../../controllers/user.controller')
 
 module.exports = async (parent, args, context) => {
-    const user = await userController.deleteUser(context.user, args.id)
-    return user
+    return await userController.deleteUser(context.user, args.id)
 }

--- a/src/graphql/typeDefs/Mutation.gql
+++ b/src/graphql/typeDefs/Mutation.gql
@@ -26,9 +26,9 @@ type Mutation {
 
     """
     PROTECTED
-    Used for delete a user in the system, requires a valid user id. Returns a User type (click User to see more).
+    Used for delete a user in the system, requires a valid user id. Returns a String.
     """
-    deleteUser(id: ID!): User!
+    deleteUser(id: ID!): String!
 
     """
     PROTECTED


### PR DESCRIPTION
# Description
now a admin can't delete a admin (wontfix)

## Type
- [X] Bug fix
- [ ] New feature
- [ ] Refactor

## Evidence

Mutation
![image](https://user-images.githubusercontent.com/83357673/215587698-1f17a0a7-f456-47d4-9e93-bd31f2a1d7b4.png)

Console
![image](https://user-images.githubusercontent.com/83357673/215587651-e58b4b41-9fc4-4499-b15f-99597b3020c8.png)

Users privilegies
![image](https://user-images.githubusercontent.com/83357673/215587888-d072d411-5837-40de-9be8-3a43d179b667.png)


